### PR TITLE
added support for linux-5.15.167

### DIFF
--- a/qca-mcs/patches/0001-kernel-5.10-compat.patch
+++ b/qca-mcs/patches/0001-kernel-5.10-compat.patch
@@ -1,20 +1,33 @@
 --- a/mc_forward.c
 +++ b/mc_forward.c
-@@ -403,7 +403,7 @@
+@@ -332,7 +332,11 @@
+ 	struct hlist_head *rhead = NULL;
+ 	int is_management;
+ 	int passup = 0;
+-
++	bool promisc;
++	
++	struct net_device *brdev = BR_INPUT_SKB_CB(skb)->brdev;
++	promisc = !!(brdev->flags & IFF_PROMISC);
++	
+ 	eh = eth_hdr(skb);
+ 	etype = ntohs(eh->h_proto);
+ 
+@@ -403,7 +407,7 @@
  
  		if (passup) {
  			/*multicast router is enabled, passing up for routing*/
 -			os_br_pass_frame_up(skb);
-+			os_br_pass_frame_up(skb, false);
++			os_br_pass_frame_up(skb, promisc);
  		} else
  			kfree_skb(skb);
  		return 0;
-@@ -434,7 +434,7 @@
+@@ -434,7 +438,7 @@
  		mc_do_router_flood(mdb, rhead, skb);
  
  	if (passup)
 -		os_br_pass_frame_up(skb);
-+		os_br_pass_frame_up(skb, false);
++		os_br_pass_frame_up(skb, promisc);
  	else
  		kfree_skb(skb);
  

--- a/qca-mcs/patches/0001-kernel-5.10-compat.patch
+++ b/qca-mcs/patches/0001-kernel-5.10-compat.patch
@@ -1,6 +1,38 @@
+--- a/mc_forward.c
++++ b/mc_forward.c
+@@ -403,7 +403,7 @@
+ 
+ 		if (passup) {
+ 			/*multicast router is enabled, passing up for routing*/
+-			os_br_pass_frame_up(skb);
++			os_br_pass_frame_up(skb, false);
+ 		} else
+ 			kfree_skb(skb);
+ 		return 0;
+@@ -434,7 +434,7 @@
+ 		mc_do_router_flood(mdb, rhead, skb);
+ 
+ 	if (passup)
+-		os_br_pass_frame_up(skb);
++		os_br_pass_frame_up(skb, false);
+ 	else
+ 		kfree_skb(skb);
+ 
 --- a/mc_osdep.h
 +++ b/mc_osdep.h
-@@ -189,7 +189,7 @@ static inline struct net_bridge_port *mc
+@@ -22,9 +22,9 @@
+ #include <br_private.h>
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0))
+-static inline int os_br_pass_frame_up(struct sk_buff *skb)
++static inline int os_br_pass_frame_up(struct sk_buff *skb, bool promisc)
+ {
+-	return br_pass_frame_up(skb);
++	return br_pass_frame_up(skb, promisc);
+ }
+ #else
+ static inline int os_br_pass_frame_up(struct sk_buff *skb)
+@@ -189,7 +189,7 @@
  
  	dst = os_br_fdb_get((struct net_bridge *)br, eth_hdr(*skb)->h_dest);
  
@@ -11,7 +43,7 @@
  	return NULL;
 --- a/mc_snooping.c
 +++ b/mc_snooping.c
-@@ -3450,6 +3450,18 @@ static int mc_proc_snooper_open(struct i
+@@ -3442,6 +3442,18 @@
          return single_open(file, mc_proc_snooper_show, NULL);
  }
  
@@ -30,7 +62,7 @@
  static const struct file_operations mc_proc_snooper_fops = {
          .owner          = THIS_MODULE,
          .open           = mc_proc_snooper_open,
-@@ -3457,6 +3469,7 @@ static const struct file_operations mc_p
+@@ -3449,6 +3461,7 @@
          .llseek         = seq_lseek,
          .release        = single_release,
  };


### PR DESCRIPTION
Additional NSS patches are required when _qca-msc_ is compiled against 23.05.5 with linux-5.15.167. The  `br_pass_frame_up` signature has changed and it now requires that an extra argument (promisc) is passed in. This PR contains the required changes for the _qca-msc_ package and should be merged when the respective linux-5.15.167 support PR in the openwrt fork is merged.